### PR TITLE
Force the resid type to be an integer

### DIFF
--- a/src/python/sasio.py
+++ b/src/python/sasio.py
@@ -440,7 +440,7 @@ class Files(object):
 			
             this_index = self._index[i]
 	
-            this_resid = self._resid[i]
+            this_resid = int(self._resid[i])
 
             if(this_index > 99999):
                 this_index = '99999'


### PR DESCRIPTION
This change makes it so the `write_pdb()` method produces pdb files the `read_pdb()` method can read.
