### PR TITLE
Add nice progressbar to python read_dcd

### DIFF
--- a/src/python/sasio.py
+++ b/src/python/sasio.py
@@ -294,9 +294,14 @@ class Files(object):
         num_fixed=0 
         result=1
 
+        
         sum=0.0
+        print('Reading DCD')
         for i in xrange(nset):
-            print '.',
+            sys.stdout.write('\r')
+            
+            eq = int(numpy.ceil(numpy.true_divide(i*100,nset*5)))
+            sys.stdout.write("[{:20s}] {}/{} frames  ".format('='*eq, i+1,nset))
             sys.stdout.flush()
             read_start_time=time.time()
             tx=numpy.zeros(nnatoms,dtype=numpy.float32)
@@ -309,7 +314,7 @@ class Files(object):
             sum+=read_end_time-read_start_time
 
             coor[i,:,0]=tx.astype(numpy.float) ; coor[i,:,1]=ty.astype(numpy.float) ; coor[i,:,2]=tz.astype(numpy.float)
-	
+        print	
         result = dcdio.close_dcd_read(infile)
         self._coor=numpy.array(coor)
 


### PR DESCRIPTION
Changed the output of read dcd from multiple .'s to
[====================] 3449/3449. This updates on the same line as more
frames are read.

This prevents excessively long outputs when calling read_dcd along with
being more informative as to the number of frames read.
